### PR TITLE
[Fix] Fix the Error of q, k, and v states must have the same dtype when using flash attention forward.

### DIFF
--- a/mergoo/models/modeling_llama.py
+++ b/mergoo/models/modeling_llama.py
@@ -541,8 +541,8 @@ class LlamaFlashAttention2(LlamaAttention):
             cu_seqlens_q, cu_seqlens_k = cu_seq_lens
             max_seqlen_in_batch_q, max_seqlen_in_batch_k = max_seq_lens
 
-            input_dtype = query_states.dtype
-            if input_dtype == torch.float32:
+            # check if any state of q, k, and v has different dtype
+            if not (query_states.dtype == key_states.dtype == value_states.dtype):
                 if torch.is_autocast_enabled():
                     target_dtype = torch.get_autocast_gpu_dtype()
                 # Handle the case where the model is quantized

--- a/mergoo/models/modeling_llama.py
+++ b/mergoo/models/modeling_llama.py
@@ -541,6 +541,26 @@ class LlamaFlashAttention2(LlamaAttention):
             cu_seqlens_q, cu_seqlens_k = cu_seq_lens
             max_seqlen_in_batch_q, max_seqlen_in_batch_k = max_seq_lens
 
+            input_dtype = query_states.dtype
+            if input_dtype == torch.float32:
+                if torch.is_autocast_enabled():
+                    target_dtype = torch.get_autocast_gpu_dtype()
+                # Handle the case where the model is quantized
+                elif hasattr(self.config, "_pre_quantization_dtype"):
+                    target_dtype = self.config._pre_quantization_dtype
+                else:
+                    target_dtype = self.q_proj.weight.dtype
+
+                logger.warning_once(
+                    f"The input hidden states seems to be silently casted in float32, this might be related to"
+                    f" the fact you have upcasted embedding or layer norm layers in float32. We will cast back the input in"
+                    f" {target_dtype}."
+                )
+
+                query_states = query_states.to(target_dtype)
+                key_states = key_states.to(target_dtype)
+                value_states = value_states.to(target_dtype)
+
             attn_output_unpad = flash_attn_varlen_func(
                 query_states,
                 key_states,


### PR DESCRIPTION
## Step for Error Reproduction 
Once we enable the argument `use_cache=True` in the Hugging Face generation_config something like the following:
```python
generation_config = GenerationConfig(
            bos_token_id=128000,
            eos_token_id=128001,
            pad_token_id=self.tokenizer.pad_token_id,
            use_cache=True,
)
```
You can simply pass the generation config with `use_cache=True` to model and make it forward as usual, and I believe you'll get the error I met.

## Error Message
I will get the following error message: "query and key must have the same dtype". And I found that this is due to the misalignment between the `dtype` of `query_state` and `value_state`.

## Potential Solution
I guess there exists potential casting for q, k, and v states. Hence, I try to cast back the `dtype` of q, k, and v to the same target `dtype`.

## Reference
The committed code I wrote strongly refers to the existing [implementation](https://github.com/Leeroo-AI/mergoo/blob/eb0586d5998211a32494dc81d1d329e770e57a11/mergoo/models/modeling_llama.py#L474-L492) in mergoo.